### PR TITLE
Button to Switch Display Properties between Flexbox and Grid for the Main Area in the website! 

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
             <button class="display-switch-button" id="display-switch">Display with CSS Flexbox!</button>
         </div>
 
-        <main>
+        <main id="exhibit-area">
             <!-- This is the display area for the buttons elements labeled with numbers! -->
             <div class="testing-exhibit-card">
                 <h2>Exhibit 1: Flex Design with Button Elements Labeled with Numbers</h2>

--- a/index.html
+++ b/index.html
@@ -81,8 +81,8 @@
         <footer>Created by TechEvolvace</footer>
     </div>
 
-
-    
+    <!-- Linking this HTML page to the JavaScript script.js file! -->
+    <script src="./script.js"></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,9 +13,13 @@
             <header>Button CSS Design Testing Ground</header>
         </nav>
 
-        <main>
-            <!-- Add an area to display the current display property for the main area and a button to switch between CSS "Flexbox" and "Grid" -->
+        <!-- Add an area to display the current display property for the main area and a button to switch between CSS "Flexbox" and "Grid" -->
+        <div class="main-display-property-switch">
+            <p id="current-display-message">Currently Displaying with CSS Grid!</p><br>
+            <button class="display-switch-button" id="display-switch">Display with CSS Flexbox!</button>
+        </div>
 
+        <main>
             <!-- This is the display area for the buttons elements labeled with numbers! -->
             <div class="testing-exhibit-card">
                 <h2>Exhibit 1: Flex Design with Button Elements Labeled with Numbers</h2>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
         <!-- Add an area to display the current display property for the main area and a button to switch between CSS "Flexbox" and "Grid" -->
         <div class="main-display-property-switch">
-            <p id="current-display-message">Currently Displaying with CSS Grid!</p><br>
+            <p id="current-display-message">Currently Displaying with CSS Grid!</p>
             <button class="display-switch-button" id="display-switch">Display with CSS Flexbox!</button>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -1,0 +1,40 @@
+let currentDisplayProperty = "Grid"; 
+
+function determineMessageOnButton(switchDisplayButton){
+    if(currentDisplayProperty === "Grid"){
+        switchDisplayButton.textContent = `Display with CSS Flexbox`;
+    } else {
+        switchDisplayButton.textContent = `Display with CSS Grid`; 
+    }
+}
+
+function currentDisplayMessage(messageArea){
+    messageArea.textContent = `Currently Displaying with CSS ${currentDisplayProperty}`;
+}
+
+function determineNewProperty(){
+    return (currentDisplayProperty === "Grid" ? currentDisplayProperty = "Flexbox" : currentDisplayProperty = "Grid"); 
+}
+
+function switchProperty(){
+
+    // Get the main element 
+    let mainSection = document.querySelector("main");
+    currentDisplayProperty = determineNewProperty(); 
+    
+    /* This doesn't affect how the exhibits are displayed! 
+    if(currentDisplayProperty === "Grid"){
+        mainSection.style.gridTemplateColumns = `repeat(2, 1fr)`; 
+        mainSection.style.gridTemplateRows = `auto`; 
+    } else {
+        mainSection.style.flexDirection = `column`;
+        mainSection.style.justifyContent = `center`;
+        mainSection.style.alignItems = `space-around`;
+    }
+    */
+
+    currentDisplayMessage(document.getElementById("current-display-message")); 
+    determineMessageOnButton(document.getElementById("display-switch"));
+}
+
+document.getElementById("display-switch").addEventListener("click", switchProperty);

--- a/styles.css
+++ b/styles.css
@@ -26,6 +26,24 @@ nav{
     justify-content: center;
 }
 
+.main-display-property-switch{
+    display: flex;
+    background-color: #7fcdff; 
+    justify-content: center;
+    align-items: center;
+    padding: 0.25rem;
+}
+
+.display-switch-button{
+    display: flex;
+    background-color: green;
+    border: 1px solid transparent;
+    border-radius: 25px;
+    color: white;
+    margin: 0.5rem;
+    padding: 0.5rem;
+}
+
 /* For screen width larger than 550px, displays each exhibit in a 2-column grid */
 main{
     display: grid;
@@ -33,20 +51,7 @@ main{
     grid-template-columns: 1fr 1fr; 
     grid-template-rows: auto; 
     grid-template-areas:
-        ".main-display-property-switch .main-display-property-switch"
         ".display-area .display-area";
-}
-
-/* Only when screen width is less than or equal to 550px (the equivalent of a mobile phone screen size),
-    displays each exhibit vertically! */
-@media only screen and (max-width: 550px){
-    main{
-        background-color: #E8ECEF;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: space-around;
-    }
 }
 
 /* Designs a footer with the credits centered on screen! */
@@ -63,6 +68,18 @@ header, footer{
     font-size: 2em; 
     padding: 5%; 
 }
+
+/* Only when screen width is less than or equal to 550px (the equivalent of a mobile phone screen size),
+    displays each exhibit vertically! */
+    @media only screen and (max-width: 550px){
+        main{
+            background-color: #E8ECEF;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: space-around;
+        }
+    }
 
 /* Designs the exhibit card that contains each CSS-associated testing ground! */
 .testing-exhibit-card{

--- a/styles.css
+++ b/styles.css
@@ -29,9 +29,10 @@ nav{
 .main-display-property-switch{
     display: flex;
     background-color: #7fcdff; 
-    justify-content: center;
+    justify-content: space-evenly;
     align-items: center;
     padding: 0.25rem;
+    font-size: 1.25rem;
 }
 
 .display-switch-button{
@@ -40,8 +41,9 @@ nav{
     border: 1px solid transparent;
     border-radius: 25px;
     color: white;
-    margin: 0.5rem;
-    padding: 0.5rem;
+    margin: 1rem 1rem;
+    padding: 1rem 1rem;
+    font-size: 1.25rem;
 }
 
 /* For screen width larger than 550px, displays each exhibit in a 2-column grid */
@@ -71,7 +73,15 @@ header, footer{
 
 /* Only when screen width is less than or equal to 550px (the equivalent of a mobile phone screen size),
     displays each exhibit vertically! */
-    @media only screen and (max-width: 550px){
+    @media only screen and (width <= 550px){
+        .main-display-property-switch{
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: space-around;
+            font-size: 1.25rem;
+        }
+
         main{
             background-color: #E8ECEF;
             display: flex;

--- a/styles.css
+++ b/styles.css
@@ -46,6 +46,10 @@ nav{
     font-size: 1.25rem;
 }
 
+.display-switch-button:hover{
+    background-color: #00b300;
+}
+
 /* For screen width larger than 550px, displays each exhibit in a 2-column grid */
 main{
     display: grid;
@@ -112,8 +116,9 @@ header, footer{
     /* Specify gap between each element, 1st number is for vertical, 2nd number is for horizontal */
     gap: 20px 20px; 
     /* Wraps the last element above and follows a reverse order of elements */
-    flex-wrap:wrap;
+    flex-wrap: wrap;
     margin: 10px;
+    flex: 1 1 auto;
 }
 
 /* Buttons */
@@ -138,6 +143,6 @@ header, footer{
 }
 
 #press-me:hover{
-    /* When mouse hovers over this big button, will enlarge the button's size to 3 times its original size!*/
-    transform: scale(3);
+    /* When mouse hovers over this big button, will enlarge the button's size to 2 times its original size!*/
+    transform: scaleX(2) scaleY(2);
 }


### PR DESCRIPTION
# Changes: 
* Added a separate area to contain the message about the current display property of the main area and the button to switch display properties between CSS Grid and CSS flexbox 
* Added a button that changes message between "Display with CSS Grid" or "Display with CSS Flexbox" depending on the current display property of the main area that contains all the exhibits! 
* Added an interactive display message that changes what current display property of the main area is displayed in the message at the click of the button 
* Ensured responsive design for the area with this display message and the button to adapt to different screen widths (one for greater than 550 px and one for less than or equal to 550 px) 

# Issues: 
* Exhibits are unchanged in appearance despite clicking the button to switch the display properties. Will need to get that resolved! 